### PR TITLE
Ignore files other than .js, .es, .jsx or .es6

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,13 @@
 var to5 = require("6to5-core");
 
 module.exports = {
-  process: function (src, filename) {
+  process: function(src, filename) {
+    // Ignore files other than .js, .es, .jsx or .es6
+    if (!to5.canCompile(filename)) {
+      return '';
+    }
     // Ignore all files within node_modules
-    // 6to5 files can be .js, .es, .jsx or .es6
-    if (filename.indexOf("node_modules") === -1 && to5.canCompile(filename)) {
+    if (filename.indexOf('node_modules') === -1) {
       return to5.transform(src, { filename: filename }).code;
     }
     return src;


### PR DESCRIPTION
Otherwise, files having statements like `require('./image.png')` fail (hello Webpack users).