### PR TITLE
Use Babel retainLines option

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,13 +5,14 @@ module.exports = {
     // Allow the stage to be configured by an environment
     // variable, but use Babel's default stage (2) if
     // no environment variable is specified.
-    var stage = process.env.BABEL_JEST_STAGE || 2
+    var stage = process.env.BABEL_JEST_STAGE || 2;
 
     // Ignore all files within node_modules
     // babel files can be .js, .es, .jsx or .es6
     if (filename.indexOf("node_modules") === -1 && babel.canCompile(filename)) {
-      return babel.transform(src, { filename: filename, stage: stage }).code;
+      return babel.transform(src, { filename: filename, stage: stage, retainLines: true }).code;
     }
+
     return src;
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "babel-jest",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "repository": "babel/babel-jest",
   "dependencies": {
-    "babel-core": "^5.0.0"
+    "babel-core": "^5.2.9"
   }
 }


### PR DESCRIPTION
Show right line numbers when there are errors in jest tests.
Fix #19.