### PR TITLE
Add environment variable for Babel runtime

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,10 +7,20 @@ module.exports = {
     // no environment variable is specified.
     var stage = process.env.BABEL_JEST_STAGE || 2;
 
+    // Allow the Babel runtime to be included via an
+    // environment variable. Remember to add
+    // node_modules/babel to unmockedModulePathPatterns
+    var optional = process.env.BABEL_JEST_RUNTIME ? [ "runtime" ] : undefined;
+
     // Ignore all files within node_modules
     // babel files can be .js, .es, .jsx or .es6
     if (filename.indexOf("node_modules") === -1 && babel.canCompile(filename)) {
-      return babel.transform(src, { filename: filename, stage: stage, retainLines: true }).code;
+      return babel.transform(src, {
+        filename: filename,
+        stage: stage,
+        retainLines: true,
+        optional: optional
+      }).code;
     }
 
     return src;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "5.2.0",
   "repository": "babel/babel-jest",
   "dependencies": {
-    "babel-core": "^5.2.9"
+    "babel-core": "^5.2.9",
+    "babel-runtime": "^5.2.17"
   }
 }


### PR DESCRIPTION
Allows the testing of ES6 features that rely on the runtime, simply supply `BABEL_JEST_RUNTIME=1` when running the `jest` command.

In order for this to work with automocking, `node_modules/babel` must be added to the `unmockedModulePathPatterns` property of the jest configuration. I have included a reminder of this as a comment.

I have included `babel-runtime` as a dependency.