### PR TITLE
Change auxiliaryComment to auxiliaryCommentBefore as of babel 5.5.7

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = {
         filename: filename,
         stage: stage,
         retainLines: true,
-        auxiliaryComment: "istanbul ignore next"
+        auxiliaryCommentBefore: "istanbul ignore next"
       }).code;
     }
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "5.2.1",
   "repository": "babel/babel-jest",
   "dependencies": {
-    "babel-core": "^5.2.9"
+    "babel-core": "^5.5.7"
   }
 }


### PR DESCRIPTION
Fixes babel-jest outputting a warning for every file touched after https://github.com/babel/babel/commit/b761cba1355d72778afa6e6076c37ba01a5c0ece