### PR TITLE
Add polyfill.js file to be used with Jest's 'setupEnvScriptFile' configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ Make the following changes to `package.json`:
 }
 ```
 
+To use the Babel polyfill, add the following to the `"jest"` configuration in `package.json`:
+
+```json
+"jest": {
+  "setupEnvScriptFile": "<rootDir>/node_modules/babel-jest/polyfill.js",
+  "unmockedModulePathPatterns": ["node_modules/babel-core"]
+}
+```
+
 And run:
 
     $ npm install

--- a/polyfill.js
+++ b/polyfill.js
@@ -1,0 +1,1 @@
+module.exports = require("babel-core/polyfill");


### PR DESCRIPTION
This exposes babel-core's polyfill, so that Jest can execute it before running tests. For simple uses of Jest without other preprocessing, they can use the polyfill directly; for more complex cases they can require `babel-jest/polyfill` in their own env script files.

Test Plan: Add the `polyfill.js` and Jest configuration to a local installation of babel-jest. Verify my tests fail before change, pass after change.