### PR TITLE
Using preprocessorIgnorePatterns config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Make the following changes to `package.json`:
   },
   "jest": {
     "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
+    "preprocessorIgnorePatterns": ["/node_modules/"],
     "testFileExtensions": ["es6", "js"],
     "moduleFileExtensions": ["js", "json", "es6"]
   }

--- a/index.js
+++ b/index.js
@@ -7,9 +7,8 @@ module.exports = {
     // no environment variable is specified.
     var stage = process.env.BABEL_JEST_STAGE || 2;
 
-    // Ignore all files within node_modules
-    // babel files can be .js, .es, .jsx or .es6
-    if (filename.indexOf("node_modules") === -1 && babel.canCompile(filename)) {
+    // Babel files can be .js, .es, .jsx or .es6
+    if (babel.canCompile(filename)) {
       return babel.transform(src, {
         filename: filename,
         stage: stage,


### PR DESCRIPTION
It is better to use `preprocessorIgnorePatterns` jest config option to skip `node_modules` processing.

I just want to process some of my external modules by babel.