### PR TITLE
Allow a specific node_modules/{foo,bar,baz,quux} to be included by the scriptPreprocessor function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,15 @@ And run:
 
 **And you're good to go!**
 
-## Processing of node_modules/
+## Processing of node_modules
 
 Under certain conditions it may be desirable to have `babel-jest`
-process against files (such as symlinks) in the `node_modules/` folder.
+process against files (such as symlinks) in the `node_modules` folder.
 
 This can be achieved by setting the environmental variable:
 
 ```shell
 BABEL_JEST_PROCESS_MODULES='["foo", "bar", "baz"]'; jest
 ```
+
+Where `foo`, `bar`, `baz` are modules within your `node_modules` folder.

--- a/README.md
+++ b/README.md
@@ -28,3 +28,14 @@ And run:
     $ npm install
 
 **And you're good to go!**
+
+## Processing of node_modules/
+
+Under certain conditions it may be desirable to have `babel-jest`
+process against files (such as symlinks) in the `node_modules/` folder.
+
+This can be achieved by setting the environmental variable:
+
+```shell
+BABEL_JEST_PROCESS_MODULES='["foo", "bar", "baz"]'; jest
+```

--- a/index.js
+++ b/index.js
@@ -7,9 +7,20 @@ module.exports = {
     // no environment variable is specified.
     var stage = process.env.BABEL_JEST_STAGE || 2;
 
-    // Ignore all files within node_modules
+    // Allow the the processor to be configured to process specific
+    // modules within the node_modules/ folder, i.e, symbolic links used to 
+    // shorthand src/ filepaths.
+    var processModules = JSON.parse(process.env.BABEL_JEST_PROCESS_MODULES || "null") || [];
+    for (var i = 0, ok = false; i < processModules.length; i++) {
+      if (filename.indexOf(path.join(process.cwd(), "node_modules", processModules[i])) === 0) {
+        ok = true;
+        break;
+      }
+    }
+
+    // Ignore all other files within node_modules
     // babel files can be .js, .es, .jsx or .es6
-    if (filename.indexOf("node_modules") === -1 && babel.canCompile(filename)) {
+    if ((ok || filename.indexOf("node_modules") === -1) && babel.canCompile(filename)) {
       return babel.transform(src, {
         filename: filename,
         stage: stage,

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var babel = require("babel-core");
+var path = require("path");
 
 module.exports = {
   process: function (src, filename) {

--- a/index.js
+++ b/index.js
@@ -9,13 +9,17 @@ module.exports = {
     var stage = process.env.BABEL_JEST_STAGE || 2;
 
     // Allow the the processor to be configured to process specific
-    // modules within the node_modules/ folder, i.e, symbolic links used to 
+    // modules within the node_modules/ folder, i.e, symbolic links used to
     // shorthand src/ filepaths.
     var processModules = JSON.parse(process.env.BABEL_JEST_PROCESS_MODULES || "null") || [];
     for (var i = 0, ok = false; i < processModules.length; i++) {
       if (filename.indexOf(path.join(process.cwd(), "node_modules", processModules[i])) === 0) {
-        ok = true;
-        break;
+        // Don't process any of the modules own node_modules, just b/c their
+        // filepath happens to match the previous test...
+        if (filename.match(/node_modules/g).length === 1)  {
+          ok = true;
+          break;
+        }
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = {
 
     // Ignore all other files within node_modules
     // babel files can be .js, .es, .jsx or .es6
-    if ((ok || filename.indexOf("node_modules") === -1) && babel.canCompile(filename)) {
+    if ((ok || filename.indexOf("node_modules") === -1) && babel.util.canCompile(filename)) {
       return babel.transform(src, {
         filename: filename,
         retainLines: true

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "6.0.1",
   "repository": "babel/babel-jest",
   "dependencies": {
-    "babel-core": "^6.3.26"
+    "babel-core": "6.3.26"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "6.0.1",
   "repository": "babel/babel-jest",
   "dependencies": {
-    "babel-core": "^6.0.0"
+    "babel-core": "^6.3.26"
   }
 }


### PR DESCRIPTION
The [browserify-handbook recommends symlinking](https://github.com/substack/browserify-handbook#symlink) something like `<rootDir>/src/foo` via `<rootDir>/node_modules/foo` to avoid clumsy relative paths.  

Doing this however breaks `babel-jest` because the `scriptPreprocessor` will ignore any path that included `"node_modules"` by default. 

This PR adds an environment variable, `BABEL_JEST_PROCESS_MODULES`, which is a `JSON` string such as:

     BABEL_JEST_PROCESS_MODULES="[\"foo\", \"bar\", \"baz\", \"quux\"]"

 so that babel preprocessing will still be applied against files matching those module paths, i.e., `<rootDir>/node_modules/{foo,bar,baz,quux}/*`
