### PR TITLE
Call `babel.util.canCompile` for Babel 6

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = {
   process: function (src, filename) {
     // Ignore all files within node_modules
     // babel files can be .js, .es, .jsx or .es6
-    if (filename.indexOf("node_modules") === -1 && babel.canCompile(filename)) {
+    if (filename.indexOf("node_modules") === -1 && babel.util.canCompile(filename)) {
       return babel.transform(src, {
         filename: filename,
         retainLines: true


### PR DESCRIPTION
`canCompile` was moved off of the main babel export to `babel.util`. Tests no longer complain about `babel.canCompile` not being a function.

Prior to this diff, babel-jest 6.0.0 with the config described in the instructions errs with:

```
TypeError: babel.canCompile is not a function
    at Object.module.exports.process (node_modules/babel-jest/index.js:7:58)
```