### PR TITLE
Replace greedy versions approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Make the following changes to `package.json`:
 ```json
 {
   "devDependencies": {
-    "babel-jest": "*",
-    "jest-cli": "*"
+    "babel-jest": "~6.0.1",
+    "jest-cli": "~5.0.3"
   },
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
Hello. Recently I got unexpected test failures in CircleCI which were not happening on my machine. This was caused by the reason that babel-jest was silently updated because I followed approach in README and set version of it to `*`. To avoid such non-positive situations in the future I suggest to show good approach in README for users to set stable library which is latest now, this will help to avoid applying of breaking changes unexpectedly.

What do you think?