### PR TITLE
Fix code coverage for importing modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,13 +5,12 @@ module.exports = {
     // Ignore all files within node_modules
     // babel files can be .js, .es, .jsx or .es6
     if (filename.indexOf("node_modules") === -1 && babel.util.canCompile(filename)) {
-      var code = babel.transform(src, {
+      return babel.transform(src, {
         filename: filename,
         retainLines: true,
-        auxiliaryCommentBefore: 'istanbul ignore next'
+        auxiliaryCommentBefore: 'istanbul ignore next',
+        plugins: ['transform-runtime']
       }).code;
-
-      return code.replace('function _interopRequireDefault(obj)', '/*istanbul ignore next */\nfunction _interopRequireDefault(obj)');
     }
 
     return src;

--- a/index.js
+++ b/index.js
@@ -5,10 +5,13 @@ module.exports = {
     // Ignore all files within node_modules
     // babel files can be .js, .es, .jsx or .es6
     if (filename.indexOf("node_modules") === -1 && babel.util.canCompile(filename)) {
-      return babel.transform(src, {
+      var code = babel.transform(src, {
         filename: filename,
-        retainLines: true
+        retainLines: true,
+        auxiliaryCommentBefore: 'istanbul ignore next'
       }).code;
+
+      return code.replace('function _interopRequireDefault(obj)', '/*istanbul ignore next */\nfunction _interopRequireDefault(obj)');
     }
 
     return src;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "6.0.1",
   "repository": "babel/babel-jest",
   "dependencies": {
-    "babel-core": "^6.0.0"
+    "babel-core": "^6.0.0",
+    "babel-plugin-transform-runtime": "^6.0.0"
   }
 }


### PR DESCRIPTION
I don't expect this to be merged in, but this was the only way I could get import modules to 100 coverage. I have instructed the babel transformer to add the istanbul ignore comment and have done a search for `function _interopRequireDefault(obj)` and replaced it with `/*istanbul ignore next */\nfunction _interopRequireDefault(obj)`.

For some reason babel does not add the auxiliaryCommentBefore before the _interopRequireDefault. I'm going to add an issue on babel about it.